### PR TITLE
EDITSKS-5515: impl long to string converter

### DIFF
--- a/Cassandra.DistributedTaskQueue.Monitoring.TestService/Startup.cs
+++ b/Cassandra.DistributedTaskQueue.Monitoring.TestService/Startup.cs
@@ -12,6 +12,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new NullableLongToStringConverter()));
         services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new LongToStringConverter()));
         services.AddSingleton<IControllerFactory>(new GroboControllerFactory());
     }

--- a/Cassandra.DistributedTaskQueue.Monitoring/Api/RtqMonitoringTaskMeta.cs
+++ b/Cassandra.DistributedTaskQueue.Monitoring/Api/RtqMonitoringTaskMeta.cs
@@ -26,27 +26,27 @@ public class RtqMonitoringTaskMeta
     public long MinimalStartTicks { get; set; }
 
     [JsonPropertyName("startExecutingTicks")]
-    [JsonConverter(typeof(LongToStringConverter))]
+    [JsonConverter(typeof(NullableLongToStringConverter))]
     public long? StartExecutingTicks { get; set; }
 
     [JsonPropertyName("finishExecutingTicks")]
-    [JsonConverter(typeof(LongToStringConverter))]
+    [JsonConverter(typeof(NullableLongToStringConverter))]
     public long? FinishExecutingTicks { get; set; }
 
     [JsonPropertyName("lastModificationTicks")]
-    [JsonConverter(typeof(LongToStringConverter))]
+    [JsonConverter(typeof(NullableLongToStringConverter))]
     public long? LastModificationTicks { get; set; }
 
     [JsonPropertyName("expirationTimestampTicks")]
-    [JsonConverter(typeof(LongToStringConverter))]
+    [JsonConverter(typeof(NullableLongToStringConverter))]
     public long? ExpirationTimestampTicks { get; set; }
 
     [JsonPropertyName("expirationModificationTicks")]
-    [JsonConverter(typeof(LongToStringConverter))]
+    [JsonConverter(typeof(NullableLongToStringConverter))]
     public long? ExpirationModificationTicks { get; set; }
 
     [JsonPropertyName("executionDurationTicks")]
-    [JsonConverter(typeof(LongToStringConverter))]
+    [JsonConverter(typeof(NullableLongToStringConverter))]
     public long? ExecutionDurationTicks { get; set; }
 
     [JsonPropertyName("state")]

--- a/Cassandra.DistributedTaskQueue.Monitoring/Json/LongToStringConverter.cs
+++ b/Cassandra.DistributedTaskQueue.Monitoring/Json/LongToStringConverter.cs
@@ -1,36 +1,23 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace SkbKontur.Cassandra.DistributedTaskQueue.Monitoring.Json;
 
 /// <summary>
-///     Конвертер, которые сериализует long-и в строки вместо чисел,
-///     ибо JSON.parse() на длинных long-ах теряет последние разряды
+///     Конвертор для сериализации long в строку
+///     note: JSON.parse() при сериализации длинных чисел теряет последние разряды
 /// </summary>
-public class LongToStringConverter : JsonConverter<long?>
+public class LongToStringConverter : JsonConverter<long>
 {
-    public override long? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var value = JsonSerializer.Deserialize<string?>(ref reader);
-        if (value == null)
-        {
-            return null;
-        }
+        var value = JsonSerializer.Deserialize<string>(ref reader);
         return long.Parse(value);
     }
 
-    public override void Write(Utf8JsonWriter writer, long? value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options)
     {
-        if (value == null)
-        {
-            writer.WriteNullValue();
-        }
-        else
-        {
-            writer.WriteStringValue(value.ToString());
-        }
+        writer.WriteStringValue(value.ToString());
     }
 }

--- a/Cassandra.DistributedTaskQueue.Monitoring/Json/NullableLongToStringConverter.cs
+++ b/Cassandra.DistributedTaskQueue.Monitoring/Json/NullableLongToStringConverter.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SkbKontur.Cassandra.DistributedTaskQueue.Monitoring.Json;
+
+/// <summary>
+///     Конвертор для сериализации long? в строку
+///     note: JSON.parse() при сериализации длинных чисел теряет последние разряды
+/// </summary>
+public class NullableLongToStringConverter : JsonConverter<long?>
+{
+    public override long? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = JsonSerializer.Deserialize<string?>(ref reader);
+        if (value == null)
+        {
+            return null;
+        }
+        return long.Parse(value);
+    }
+
+    public override void Write(Utf8JsonWriter writer, long? value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4-prerelease3",
+  "version": "3.4",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
В классе `RtqMonitoringTaskMeta` есть свойства с типом данных `long` и `long?`. `JSON.parse(`) при сериализации длинных чисел теряет последние разряды. Для этого изначально был написан конвертор `LongToStringConverter` для сериализации` long?` в `string`. При тестировании я заметил, что такой конвертор не работает для типа `Int64`(long (без nullable)), написал отдельный конвертор и для этого типа.